### PR TITLE
Loosened integration with the heading feature

### DIFF
--- a/src/autoformat.js
+++ b/src/autoformat.js
@@ -127,34 +127,29 @@ export default class Autoformat extends Plugin {
 	 * Adds autoformatting related to {@link module:heading/heading~Heading}.
 	 *
 	 * It is using a number at the end of the command name to associate it with the proper trigger:
+	 *
 	 * * `heading1` will be executed when typing `#`,
 	 * * `heading2` will be executed when typing `##`,
-	 * * `heading3` will be executed when typing `###`.
+	 * * ... up to `heading6` and `######`.
 	 *
 	 * @private
 	 */
 	_addHeadingAutoformats() {
 		const commands = this.editor.commands;
-		const options = this.editor.config.get( 'heading.options' );
 
-		if ( options ) {
-			for ( const option of options ) {
-				const commandName = option.modelElement;
-				let match;
+		Array.from( commands.keys() )
+			.filter( name => name.match( /^heading[1-6]$/ ) )
+			.forEach( commandName => {
+				const level = commandName[ 7 ];
+				const pattern = new RegExp( `^(#{${ level }})\\s$` );
 
-				if ( commands.has( commandName ) && ( match = commandName.match( /\d+$/ ) ) ) {
-					const level = match[ 0 ];
-					const regExp = new RegExp( `^(#{${ level }})\\s$` );
+				// eslint-disable-next-line no-new
+				new BlockAutoformatEngine( this.editor, pattern, context => {
+					const { batch } = context;
 
-					// eslint-disable-next-line no-new
-					new BlockAutoformatEngine( this.editor, regExp, context => {
-						const { batch } = context;
-
-						this.editor.execute( commandName, { batch } );
-					} );
-				}
-			}
-		}
+					this.editor.execute( commandName, { batch } );
+				} );
+			} );
 	}
 
 	/**

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -4,16 +4,21 @@
  */
 
 import Autoformat from '../src/autoformat';
+
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ListEngine from '@ckeditor/ckeditor5-list/src/listengine';
 import HeadingEngine from '@ckeditor/ckeditor5-heading/src/headingengine';
 import BoldEngine from '@ckeditor/ckeditor5-basic-styles/src/boldengine';
 import ItalicEngine from '@ckeditor/ckeditor5-basic-styles/src/italicengine';
 import BlockQuoteEngine from '@ckeditor/ckeditor5-block-quote/src/blockquoteengine';
-import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
+import Command from '@ckeditor/ckeditor5-core/src/command/command';
 
 testUtils.createSinonSandbox();
 
@@ -29,6 +34,10 @@ describe( 'Autoformat', () => {
 			doc = editor.document;
 			batch = doc.batch();
 		} );
+	} );
+
+	afterEach( () => {
+		return editor.destroy();
 	} );
 
 	describe( 'Bulleted list', () => {
@@ -99,13 +108,60 @@ describe( 'Autoformat', () => {
 			expect( getData( doc ) ).to.equal( '<heading2>[]</heading2>' );
 		} );
 
-		it( 'should not replace minus character when inside heading', () => {
+		it( 'should not replace hash character when inside heading', () => {
 			setData( doc, '<heading1>#[]</heading1>' );
 			doc.enqueueChanges( () => {
 				batch.insert( doc.selection.getFirstPosition(), ' ' );
 			} );
 
 			expect( getData( doc ) ).to.equal( '<heading1># []</heading1>' );
+		} );
+
+		it( 'should work with heading1-heading6 commands regardless of the config of the heading feature', () => {
+			const spy1 = sinon.spy();
+			const spy6 = sinon.spy();
+
+			class Heading6 extends Command {
+				_doExecute() {
+					spy6();
+				}
+			}
+			class Heading1 extends Command {
+				_doExecute() {
+					spy1();
+				}
+			}
+
+			function HeadingPlugin( editor ) {
+				editor.commands.set( 'heading1', new Heading1() );
+				editor.commands.set( 'heading6', new Heading6() );
+			}
+
+			return VirtualTestEditor
+				.create( {
+					plugins: [
+						Paragraph, Autoformat, HeadingPlugin
+					]
+				} )
+				.then( editor => {
+					const doc = editor.document;
+
+					setData( doc, '<paragraph>#[]</paragraph>' );
+					doc.enqueueChanges( () => {
+						doc.batch().insert( doc.selection.getFirstPosition(), ' ' );
+					} );
+
+					expect( spy1.calledOnce ).to.be.true;
+
+					setData( doc, '<paragraph>######[]</paragraph>' );
+					doc.enqueueChanges( () => {
+						doc.batch().insert( doc.selection.getFirstPosition(), ' ' );
+					} );
+
+					expect( spy6.calledOnce ).to.be.true;
+
+					return editor.destroy();
+				} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The autoformat feature will not depend on the configuration of the heading feature but it will use the available `heading*` commands. Closes #29.
