### PR TITLE
Fix: LiveRanges removed by InlineAutoFormatEngine are not detached after removing.

### DIFF
--- a/src/inlineautoformatengine.js
+++ b/src/inlineautoformatengine.js
@@ -195,6 +195,9 @@ export default class InlineAutoformatEngine {
 				// Apply format.
 				formatCallback( fixBatch, validRanges );
 
+				// Detach ranges used to apply Autoformat. Prevents memory leaks. #39
+				rangesToFormat.forEach( range => range.detach() );
+
 				// Remove delimiters.
 				for ( const range of rangesToRemove ) {
 					fixBatch.remove( range );

--- a/src/inlineautoformatengine.js
+++ b/src/inlineautoformatengine.js
@@ -198,6 +198,7 @@ export default class InlineAutoformatEngine {
 				// Remove delimiters.
 				for ( const range of rangesToRemove ) {
 					fixBatch.remove( range );
+					range.detach(); // Prevents memory leaks. #39
 				}
 			} );
 		} );

--- a/src/inlineautoformatengine.js
+++ b/src/inlineautoformatengine.js
@@ -198,7 +198,10 @@ export default class InlineAutoformatEngine {
 				// Remove delimiters.
 				for ( const range of rangesToRemove ) {
 					fixBatch.remove( range );
-					range.detach(); // Prevents memory leaks. #39
+
+					// Prevents memory leaks.
+					// https://github.com/ckeditor/ckeditor5-autoformat/issues/39
+					range.detach();
 				}
 			} );
 		} );

--- a/tests/inlineautoformatengine.js
+++ b/tests/inlineautoformatengine.js
@@ -150,7 +150,7 @@ describe( 'InlineAutoformatEngine', () => {
 				doc.batch().insert( doc.selection.getFirstPosition(), '*' );
 			} );
 
-			// There should be two ranges removed
+			// There should be two ranges removed.
 			expect( detachSpies ).to.have.length( 2 );
 
 			for ( const spy of detachSpies ) {

--- a/tests/inlineautoformatengine.js
+++ b/tests/inlineautoformatengine.js
@@ -141,6 +141,9 @@ describe( 'InlineAutoformatEngine', () => {
 		it( 'should detach removed ranges', () => {
 			const detachSpies = [];
 			const callback = fixBatch => testUtils.sinon.stub( fixBatch, 'remove' ).callsFake( saveDetachSpy );
+			testUtils.sinon.stub( editor.document.schema, 'getValidRanges' )
+				.callThrough()
+				.callsFake( ranges => ranges.map( saveDetachSpy ) );
 
 			new InlineAutoformatEngine( editor, /(\*)(.+?)(\*)/g, callback ); // eslint-disable-line no-new
 
@@ -150,8 +153,8 @@ describe( 'InlineAutoformatEngine', () => {
 				doc.batch().insert( doc.selection.getFirstPosition(), '*' );
 			} );
 
-			// There should be two ranges removed.
-			expect( detachSpies ).to.have.length( 2 );
+			// There should be two removed ranges and one range used to apply autoformat.
+			expect( detachSpies ).to.have.length( 3 );
 
 			for ( const spy of detachSpies ) {
 				testUtils.sinon.assert.calledOnce( spy );

--- a/tests/inlineautoformatengine.js
+++ b/tests/inlineautoformatengine.js
@@ -137,5 +137,29 @@ describe( 'InlineAutoformatEngine', () => {
 
 			sinon.assert.notCalled( formatSpy );
 		} );
+
+		it( 'should detach removed ranges', () => {
+			const detachSpies = [];
+			const callback = fixBatch => testUtils.sinon.stub( fixBatch, 'remove' ).callsFake( saveDetachSpy );
+
+			new InlineAutoformatEngine( editor, /(\*)(.+?)(\*)/g, callback ); // eslint-disable-line no-new
+
+			setData( doc, '<paragraph>*foobar[]</paragraph>' );
+
+			doc.enqueueChanges( () => {
+				doc.batch().insert( doc.selection.getFirstPosition(), '*' );
+			} );
+
+			// There should be two ranges removed
+			expect( detachSpies ).to.have.length( 2 );
+
+			for ( const spy of detachSpies ) {
+				testUtils.sinon.assert.calledOnce( spy );
+			}
+
+			function saveDetachSpy( range ) {
+				detachSpies.push( testUtils.sinon.spy( range, 'detach' ) );
+			}
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: LiveRanges removed by InlineAutoFormatEngine are not detached after removing. Closes #39.
