### PR TITLE
Fix: Autoformat regex in numbered lists. Closes #42.

### DIFF
--- a/src/autoformat.js
+++ b/src/autoformat.js
@@ -54,7 +54,7 @@ export default class Autoformat extends Plugin {
 
 		if ( commands.get( 'numberedList' ) ) {
 			// eslint-disable-next-line no-new
-			new BlockAutoformatEngine( this.editor, /^\d+[.|)]?\s$/, 'numberedList' );
+			new BlockAutoformatEngine( this.editor, /^\d+[.|)]\s$/, 'numberedList' );
 		}
 	}
 

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -82,13 +82,31 @@ describe( 'Autoformat', () => {
 	} );
 
 	describe( 'Numbered list', () => {
-		it( 'should replace digit with numbered list item', () => {
+		it( 'should replace digit with numbered list item using the dot format', () => {
 			setData( doc, '<paragraph>1.[]</paragraph>' );
 			doc.enqueueChanges( () => {
 				batch.insert( doc.selection.getFirstPosition(), ' ' );
 			} );
 
 			expect( getData( doc ) ).to.equal( '<listItem indent="0" type="numbered">[]</listItem>' );
+		} );
+
+		it( 'should replace digit with numbered list item using the parenthesis format', () => {
+			setData( doc, '<paragraph>1)[]</paragraph>' );
+			doc.enqueueChanges( () => {
+				batch.insert( doc.selection.getFirstPosition(), ' ' );
+			} );
+
+			expect( getData( doc ) ).to.equal( '<listItem indent="0" type="numbered">[]</listItem>' );
+		} );
+
+		it( 'should not replace digit character when there is no . or ) in the format', () => {
+			setData( doc, '<paragraph>1[]</paragraph>' );
+			doc.enqueueChanges( () => {
+				batch.insert( doc.selection.getFirstPosition(), ' ' );
+			} );
+
+			expect( getData( doc ) ).to.equal( '<paragraph>1 []</paragraph>' );
 		} );
 
 		it( 'should not replace digit character when inside numbered list item', () => {

--- a/tests/manual/autoformat.md
+++ b/tests/manual/autoformat.md
@@ -6,7 +6,9 @@
 
 1. Type `>` and press the space in an empty paragraph to replace it with a block quote.
 
-1. Type a number from the range **1-3** to replace an empty paragraph with a numbered list item.
+1. Type a number from the range **1-3** followed by a `.` and press space to replace an empty paragraph with a numbered list item.
+
+1. Type a number from the range **1-3** followed by a `)` and press space to replace an empty paragraph with a numbered list item.
 
 1. Type `*foobar*`/`_foobar_` to italicize `foobar`. `*`/`_` should be removed.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Fix regex to not skip . and ) in ordered lists. Closes #42.

---
