### PR TITLE
Align feature class naming to a new scheme.

### DIFF
--- a/docs/features/autoformat.md
+++ b/docs/features/autoformat.md
@@ -68,7 +68,7 @@ ClassicEditor
 
 ## Creating custom autoformatters
 
-The {@link module:autoformat/autoformat~Autoformat} feature bases on {@link module:autoformat/blockautoformatengine~BlockAutoformatEngine} and {@link module:autoformat/inlineautoformatengine~InlineAutoformatEngine} tools to create the autoformatters mentioned above.
+The {@link module:autoformat/autoformat~Autoformat} feature bases on {@link module:autoformat/blockautoformatediting~BlockAutoformatEditing} and {@link module:autoformat/inlineautoformatediting~InlineAutoformatEditing} tools to create the autoformatters mentioned above.
 
 You can use these tools to create your own autoformatters. Check the [`Autoformat` feature's code](https://github.com/ckeditor/ckeditor5-autoformat/blob/master/src/autoformat.js) as an example.
 

--- a/src/autoformat.js
+++ b/src/autoformat.js
@@ -7,8 +7,8 @@
  * @module autoformat/autoformat
  */
 
-import BlockAutoformatEngine from './blockautoformatengine';
-import InlineAutoformatEngine from './inlineautoformatengine';
+import BlockAutoformatEditing from './blockautoformatediting';
+import InlineAutoformatEditing from './inlineautoformatediting';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 /**
@@ -49,12 +49,12 @@ export default class Autoformat extends Plugin {
 
 		if ( commands.get( 'bulletedList' ) ) {
 			// eslint-disable-next-line no-new
-			new BlockAutoformatEngine( this.editor, /^[*-]\s$/, 'bulletedList' );
+			new BlockAutoformatEditing( this.editor, /^[*-]\s$/, 'bulletedList' );
 		}
 
 		if ( commands.get( 'numberedList' ) ) {
 			// eslint-disable-next-line no-new
-			new BlockAutoformatEngine( this.editor, /^\d+[.|)]\s$/, 'numberedList' );
+			new BlockAutoformatEditing( this.editor, /^\d+[.|)]\s$/, 'numberedList' );
 		}
 	}
 
@@ -76,8 +76,8 @@ export default class Autoformat extends Plugin {
 
 		if ( commands.get( 'bold' ) ) {
 			/* eslint-disable no-new */
-			new InlineAutoformatEngine( this.editor, /(\*\*)([^*]+)(\*\*)$/g, 'bold' );
-			new InlineAutoformatEngine( this.editor, /(__)([^_]+)(__)$/g, 'bold' );
+			new InlineAutoformatEditing( this.editor, /(\*\*)([^*]+)(\*\*)$/g, 'bold' );
+			new InlineAutoformatEditing( this.editor, /(__)([^_]+)(__)$/g, 'bold' );
 			/* eslint-enable no-new */
 		}
 
@@ -86,14 +86,14 @@ export default class Autoformat extends Plugin {
 			// text before the pattern (e.g. `(?:^|[^\*])`).
 
 			/* eslint-disable no-new */
-			new InlineAutoformatEngine( this.editor, /(?:^|[^*])(\*)([^*_]+)(\*)$/g, 'italic' );
-			new InlineAutoformatEngine( this.editor, /(?:^|[^_])(_)([^_]+)(_)$/g, 'italic' );
+			new InlineAutoformatEditing( this.editor, /(?:^|[^*])(\*)([^*_]+)(\*)$/g, 'italic' );
+			new InlineAutoformatEditing( this.editor, /(?:^|[^_])(_)([^_]+)(_)$/g, 'italic' );
 			/* eslint-enable no-new */
 		}
 
 		if ( commands.get( 'code' ) ) {
 			/* eslint-disable no-new */
-			new InlineAutoformatEngine( this.editor, /(`)([^`]+)(`)$/g, 'code' );
+			new InlineAutoformatEditing( this.editor, /(`)([^`]+)(`)$/g, 'code' );
 			/* eslint-enable no-new */
 		}
 	}
@@ -117,7 +117,7 @@ export default class Autoformat extends Plugin {
 				const pattern = new RegExp( `^(#{${ level }})\\s$` );
 
 				// eslint-disable-next-line no-new
-				new BlockAutoformatEngine( this.editor, pattern, () => {
+				new BlockAutoformatEditing( this.editor, pattern, () => {
 					this.editor.execute( commandName );
 				} );
 			} );
@@ -134,7 +134,7 @@ export default class Autoformat extends Plugin {
 	_addBlockQuoteAutoformats() {
 		if ( this.editor.commands.get( 'blockQuote' ) ) {
 			// eslint-disable-next-line no-new
-			new BlockAutoformatEngine( this.editor, /^>\s$/, 'blockQuote' );
+			new BlockAutoformatEditing( this.editor, /^>\s$/, 'blockQuote' );
 		}
 	}
 }

--- a/src/blockautoformatediting.js
+++ b/src/blockautoformatediting.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module autoformat/blockautoformatengine
+ * @module autoformat/blockautoformatediting
  */
 
 import Range from '@ckeditor/ckeditor5-engine/src/model/range';
@@ -20,7 +20,7 @@ import Range from '@ckeditor/ckeditor5-engine/src/model/range';
  * the {@link module:autoformat/autoformat~Autoformat} feature which enables a set of default autoformatters
  * (lists, headings, bold and italic).
  */
-export default class BlockAutoformatEngine {
+export default class BlockAutoformatEditing {
 	/**
 	 * Creates a listener triggered on `change` event in the document.
 	 * Calls the callback when inserted text matches the regular expression or the command name
@@ -30,11 +30,11 @@ export default class BlockAutoformatEngine {
 	 *
 	 * To convert a paragraph to heading 1 when `- ` is typed, using just the commmand name:
 	 *
-	 *		new BlockAutoformatEngine( editor, /^\- $/, 'heading1' );
+	 *		new BlockAutoformatEditing( editor, /^\- $/, 'heading1' );
 	 *
 	 * To convert a paragraph to heading 1 when `- ` is typed, using just the callback:
 	 *
-	 *		new BlockAutoformatEngine( editor, /^\- $/, ( context ) => {
+	 *		new BlockAutoformatEditing( editor, /^\- $/, ( context ) => {
 	 *			const { match } = context;
 	 *			const headingLevel = match[ 1 ].length;
 	 *

--- a/src/inlineautoformatediting.js
+++ b/src/inlineautoformatediting.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module autoformat/inlineautoformatengine
+ * @module autoformat/inlineautoformatediting
  */
 
 import LiveRange from '@ckeditor/ckeditor5-engine/src/model/liverange';
@@ -20,7 +20,7 @@ import LiveRange from '@ckeditor/ckeditor5-engine/src/model/liverange';
  * the {@link module:autoformat/autoformat~Autoformat} feature which enables a set of default autoformatters
  * (lists, headings, bold and italic).
  */
-export default class InlineAutoformatEngine {
+export default class InlineAutoformatEditing {
 	/**
 	 * Enables autoformatting mechanism for a given {@link module:core/editor/editor~Editor}.
 	 *
@@ -38,7 +38,7 @@ export default class InlineAutoformatEngine {
 	 *		// - The first to match the starting `**` delimiter.
 	 *		// - The second to match the text to format.
 	 *		// - The third to match the ending `**` delimiter.
-	 *		new InlineAutoformatEngine( editor, /(\*\*)([^\*]+?)(\*\*)$/g, 'bold' );
+	 *		new InlineAutoformatEditing( editor, /(\*\*)([^\*]+?)(\*\*)$/g, 'bold' );
 	 *
 	 * When a function is provided instead of the regular expression, it will be executed with the text to match as a parameter.
 	 * The function should return proper "ranges" to delete and format.
@@ -57,10 +57,10 @@ export default class InlineAutoformatEngine {
 	 * formatting.
 	 *
 	 *		// Use attribute name:
-	 *		new InlineAutoformatEngine( editor, /(\*\*)([^\*]+?)(\*\*)$/g, 'bold' );
+	 *		new InlineAutoformatEditing( editor, /(\*\*)([^\*]+?)(\*\*)$/g, 'bold' );
 	 *
 	 *		// Use formatting callback:
-	 *		new InlineAutoformatEngine( editor, /(\*\*)([^\*]+?)(\*\*)$/g, ( writer, validRanges ) => {
+	 *		new InlineAutoformatEditing( editor, /(\*\*)([^\*]+?)(\*\*)$/g, ( writer, validRanges ) => {
 	 *			for ( let range of validRanges ) {
 	 *				writer.setAttribute( command, true, range );
 	 *			}

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -6,12 +6,12 @@
 import Autoformat from '../src/autoformat';
 
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListEngine from '@ckeditor/ckeditor5-list/src/listengine';
-import HeadingEngine from '@ckeditor/ckeditor5-heading/src/headingengine';
-import BoldEngine from '@ckeditor/ckeditor5-basic-styles/src/boldengine';
-import CodeEngine from '@ckeditor/ckeditor5-basic-styles/src/codeengine';
-import ItalicEngine from '@ckeditor/ckeditor5-basic-styles/src/italicengine';
-import BlockQuoteEngine from '@ckeditor/ckeditor5-block-quote/src/blockquoteengine';
+import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
+import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
+import CodeEditing from '@ckeditor/ckeditor5-basic-styles/src/code/codeediting';
+import ItalicEditing from '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting';
+import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
@@ -33,12 +33,12 @@ describe( 'Autoformat', () => {
 					Enter,
 					Paragraph,
 					Autoformat,
-					ListEngine,
-					HeadingEngine,
-					BoldEngine,
-					ItalicEngine,
-					CodeEngine,
-					BlockQuoteEngine
+					ListEditing,
+					HeadingEditing,
+					BoldEditing,
+					ItalicEditing,
+					CodeEditing,
+					BlockQuoteEditing
 				]
 			} )
 			.then( newEditor => {
@@ -378,7 +378,7 @@ describe( 'Autoformat', () => {
 		it( 'should use only configured headings', () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ Enter, Paragraph, Autoformat, ListEngine, HeadingEngine ],
+					plugins: [ Enter, Paragraph, Autoformat, ListEditing, HeadingEditing ],
 					heading: {
 						options: [
 							{ model: 'paragraph' },

--- a/tests/blockautoformatediting.js
+++ b/tests/blockautoformatediting.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import BlockAutoformatEngine from '../src/blockautoformatengine';
+import BlockAutoformatEditing from '../src/blockautoformatediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
@@ -13,7 +13,7 @@ import Command from '@ckeditor/ckeditor5-core/src/command';
 
 testUtils.createSinonSandbox();
 
-describe( 'BlockAutoformatEngine', () => {
+describe( 'BlockAutoformatEditing', () => {
 	let editor, model, doc;
 
 	beforeEach( () => {
@@ -32,7 +32,7 @@ describe( 'BlockAutoformatEngine', () => {
 		it( 'should run a command when the pattern is matched', () => {
 			const spy = testUtils.sinon.spy();
 			editor.commands.add( 'testCommand', new TestCommand( editor, spy ) );
-			new BlockAutoformatEngine( editor, /^[*]\s$/, 'testCommand' ); // eslint-disable-line no-new
+			new BlockAutoformatEditing( editor, /^[*]\s$/, 'testCommand' ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -45,7 +45,7 @@ describe( 'BlockAutoformatEngine', () => {
 		it( 'should remove found pattern', () => {
 			const spy = testUtils.sinon.spy();
 			editor.commands.add( 'testCommand', new TestCommand( editor, spy ) );
-			new BlockAutoformatEngine( editor, /^[*]\s$/, 'testCommand' ); // eslint-disable-line no-new
+			new BlockAutoformatEditing( editor, /^[*]\s$/, 'testCommand' ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -60,7 +60,7 @@ describe( 'BlockAutoformatEngine', () => {
 	describe( 'Callback', () => {
 		it( 'should run callback when the pattern is matched', () => {
 			const spy = testUtils.sinon.spy();
-			new BlockAutoformatEngine( editor, /^[*]\s$/, spy ); // eslint-disable-line no-new
+			new BlockAutoformatEditing( editor, /^[*]\s$/, spy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -72,7 +72,7 @@ describe( 'BlockAutoformatEngine', () => {
 
 		it( 'should ignore other delta operations', () => {
 			const spy = testUtils.sinon.spy();
-			new BlockAutoformatEngine( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
+			new BlockAutoformatEditing( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -84,7 +84,7 @@ describe( 'BlockAutoformatEngine', () => {
 
 		it( 'should stop if there is no text to run matching on', () => {
 			const spy = testUtils.sinon.spy();
-			new BlockAutoformatEngine( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
+			new BlockAutoformatEditing( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>[]</paragraph>' );
 			model.change( writer => {

--- a/tests/inlineautoformatediting.js
+++ b/tests/inlineautoformatediting.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import InlineAutoformatEngine from '../src/inlineautoformatengine';
+import InlineAutoformatEditing from '../src/inlineautoformatediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
@@ -12,7 +12,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 testUtils.createSinonSandbox();
 
-describe( 'InlineAutoformatEngine', () => {
+describe( 'InlineAutoformatEditing', () => {
 	let editor, model, doc;
 
 	beforeEach( () => {
@@ -31,7 +31,7 @@ describe( 'InlineAutoformatEngine', () => {
 
 	describe( 'attribute', () => {
 		it( 'should stop early if there are less than 3 capture groups', () => {
-			new InlineAutoformatEngine( editor, /(\*)(.+?)\*/g, 'testAttribute' ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, /(\*)(.+?)\*/g, 'testAttribute' ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*foobar[]</paragraph>' );
 			model.change( writer => {
@@ -42,7 +42,7 @@ describe( 'InlineAutoformatEngine', () => {
 		} );
 
 		it( 'should apply an attribute when the pattern is matched', () => {
-			new InlineAutoformatEngine( editor, /(\*)(.+?)(\*)/g, 'testAttribute' ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, /(\*)(.+?)(\*)/g, 'testAttribute' ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*foobar[]</paragraph>' );
 			model.change( writer => {
@@ -53,7 +53,7 @@ describe( 'InlineAutoformatEngine', () => {
 		} );
 
 		it( 'should stop early if selection is not collapsed', () => {
-			new InlineAutoformatEngine( editor, /(\*)(.+?)\*/g, 'testAttribute' ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, /(\*)(.+?)\*/g, 'testAttribute' ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*foob[ar]</paragraph>' );
 			model.change( writer => {
@@ -72,7 +72,7 @@ describe( 'InlineAutoformatEngine', () => {
 				remove: []
 			} );
 
-			new InlineAutoformatEngine( editor, testStub, formatSpy ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, testStub, formatSpy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -89,7 +89,7 @@ describe( 'InlineAutoformatEngine', () => {
 				remove: [ [] ]
 			} );
 
-			new InlineAutoformatEngine( editor, testStub, formatSpy ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, testStub, formatSpy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*[]</paragraph>' );
 			model.change( writer => {
@@ -106,7 +106,7 @@ describe( 'InlineAutoformatEngine', () => {
 				remove: [ [] ]
 			} );
 
-			new InlineAutoformatEngine( editor, testStub, formatSpy ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, testStub, formatSpy ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>[]</paragraph>' );
 			model.change( writer => {
@@ -123,7 +123,7 @@ describe( 'InlineAutoformatEngine', () => {
 				.callThrough()
 				.callsFake( ranges => ranges.map( saveDetachSpy ) );
 
-			new InlineAutoformatEngine( editor, /(\*)(.+?)(\*)/g, callback ); // eslint-disable-line no-new
+			new InlineAutoformatEditing( editor, /(\*)(.+?)(\*)/g, callback ); // eslint-disable-line no-new
 
 			setData( model, '<paragraph>*foobar[]</paragraph>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Align feature class naming to a new scheme.

BREAKING CHANGE: Renamed `BlockAutoformatEngine` to `BlockAutoformatEditing`.
BREAKING CHANGE: Renamed `InlineAutoformatEngine` to `InlineAutoformatEditing`.

---

### Additional information

* Part of feature split: https://github.com/ckeditor/ckeditor5/issues/488
