### PR TITLE
Autoformat should ignore transparent batches

### DIFF
--- a/src/blockautoformatediting.js
+++ b/src/blockautoformatediting.js
@@ -63,7 +63,11 @@ export default class BlockAutoformatEditing {
 			};
 		}
 
-		editor.model.document.on( 'change', () => {
+		editor.model.document.on( 'change', ( evt, batch ) => {
+			if ( batch.type == 'transparent' ) {
+				return;
+			}
+
 			const changes = Array.from( editor.model.document.differ.getChanges() );
 			const entry = changes[ 0 ];
 

--- a/src/inlineautoformatediting.js
+++ b/src/inlineautoformatediting.js
@@ -140,7 +140,11 @@ export default class InlineAutoformatEditing {
 			writer.removeSelectionAttribute( attributeKey );
 		} );
 
-		editor.model.document.on( 'change', () => {
+		editor.model.document.on( 'change', ( evt, batch ) => {
+			if ( batch.type == 'transparent' ) {
+				return;
+			}
+
 			const selection = editor.model.document.selection;
 
 			// Do nothing if selection is not collapsed.

--- a/tests/blockautoformatediting.js
+++ b/tests/blockautoformatediting.js
@@ -94,6 +94,18 @@ describe( 'BlockAutoformatEditing', () => {
 			sinon.assert.notCalled( spy );
 		} );
 	} );
+
+	it( 'should ignore transparent batches', () => {
+		const spy = testUtils.sinon.spy();
+		new BlockAutoformatEditing( editor, /^[*]\s$/, spy ); // eslint-disable-line no-new
+
+		setData( model, '<paragraph>*[]</paragraph>' );
+		model.enqueueChange( 'transparent', writer => {
+			writer.insertText( ' ', doc.selection.getFirstPosition() );
+		} );
+
+		sinon.assert.notCalled( spy );
+	} );
 } );
 
 /**

--- a/tests/inlineautoformatediting.js
+++ b/tests/inlineautoformatediting.js
@@ -116,4 +116,15 @@ describe( 'InlineAutoformatEditing', () => {
 			sinon.assert.notCalled( formatSpy );
 		} );
 	} );
+
+	it( 'should ignore transparent batches', () => {
+		new InlineAutoformatEditing( editor, /(\*)(.+?)(\*)/g, 'testAttribute' ); // eslint-disable-line no-new
+
+		setData( model, '<paragraph>*foobar[]</paragraph>' );
+		model.enqueueChange( 'transparent', writer => {
+			writer.insertText( '*', doc.selection.getFirstPosition() );
+		} );
+
+		expect( getData( model ) ).to.equal( '<paragraph>*foobar*[]</paragraph>' );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Autoformat should ignore transparent batches. Closes #56.