### PR TITLE
Remove Position, Range, Selection imports from engine/model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-core": "^11.0.1",
-    "@ckeditor/ckeditor5-engine": "^11.0.0"
+    "@ckeditor/ckeditor5-core": "^11.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^10.0.3",
     "@ckeditor/ckeditor5-block-quote": "^10.1.0",
     "@ckeditor/ckeditor5-cloud-services": "^10.1.0",
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
+    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-enter": "^10.1.2",
     "@ckeditor/ckeditor5-heading": "^10.1.0",
     "@ckeditor/ckeditor5-list": "^11.0.2",

--- a/src/blockautoformatediting.js
+++ b/src/blockautoformatediting.js
@@ -7,8 +7,6 @@
  * @module autoformat/blockautoformatediting
  */
 
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-
 /**
  * The block autoformatting engine. It allows to format various block patterns. For example,
  * it can be configured to turn a paragraph starting with `*` and followed by a space into a list item.
@@ -90,7 +88,9 @@ export default class BlockAutoformatEditing {
 			// Use enqueueChange to create new batch to separate typing batch from the auto-format changes.
 			editor.model.enqueueChange( writer => {
 				// Matched range.
-				const range = Range.createFromParentsAndOffsets( item.parent, 0, item.parent, match[ 0 ].length );
+				const start = writer.createPositionAt( item.parent, 0 );
+				const end = writer.createPositionAt( item.parent, match[ 0 ].length );
+				const range = writer.createRange( start, end );
 
 				// Remove matched text.
 				writer.remove( range );

--- a/src/inlineautoformatediting.js
+++ b/src/inlineautoformatediting.js
@@ -7,8 +7,6 @@
  * @module autoformat/inlineautoformatediting
  */
 
-import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
-
 /**
  * The inline autoformatting engine. It allows to format various inline patterns. For example,
  * it can be configured to make "foo" bold when typed `**foo**` (the `**` markers will be removed).
@@ -163,8 +161,8 @@ export default class InlineAutoformatEditing {
 			const block = selection.focus.parent;
 			const text = getText( block ).slice( 0, selection.focus.offset );
 			const testOutput = testCallback( text );
-			const rangesToFormat = testOutputToRanges( block, testOutput.format );
-			const rangesToRemove = testOutputToRanges( block, testOutput.remove );
+			const rangesToFormat = testOutputToRanges( block, testOutput.format, editor.model );
+			const rangesToRemove = testOutputToRanges( block, testOutput.remove, editor.model );
 
 			if ( !( rangesToFormat.length && rangesToRemove.length ) ) {
 				return;
@@ -201,8 +199,11 @@ function getText( element ) {
 // @private
 // @param {module:engine/model/element~Element} block
 // @param {Array.<Array>} arrays
-function testOutputToRanges( block, arrays ) {
+// @param {module:engine/model/model~Model} model
+function testOutputToRanges( block, arrays, model ) {
 	return arrays
 		.filter( array => ( array[ 0 ] !== undefined && array[ 1 ] !== undefined ) )
-		.map( array => ModelRange.createFromParentsAndOffsets( block, array[ 0 ], block, array[ 1 ] ) );
+		.map( array => {
+			return model.createRange( model.createPositionAt( block, array[ 0 ] ), model.createPositionAt( block, array[ 1 ] ) );
+		} );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
