### PR TITLE
It should be possible to disable autoformatting

### DIFF
--- a/src/blockautoformatediting.js
+++ b/src/blockautoformatediting.js
@@ -26,7 +26,7 @@ export default class BlockAutoformatEditing {
 	 *
 	 * Examples of usage:
 	 *
-	 * To convert a paragraph to heading 1 when `- ` is typed, using just the commmand name:
+	 * To convert a paragraph to heading 1 when `- ` is typed, using just the command name:
 	 *
 	 *		new BlockAutoformatEditing( editor, /^\- $/, 'heading1' );
 	 *
@@ -49,19 +49,24 @@ export default class BlockAutoformatEditing {
 	 */
 	constructor( editor, pattern, callbackOrCommand ) {
 		let callback;
+		let command = null;
 
 		if ( typeof callbackOrCommand == 'function' ) {
 			callback = callbackOrCommand;
 		} else {
 			// We assume that the actual command name was provided.
-			const command = callbackOrCommand;
+			command = editor.commands.get( callbackOrCommand );
 
 			callback = () => {
-				editor.execute( command );
+				editor.execute( callbackOrCommand );
 			};
 		}
 
 		editor.model.document.on( 'change', ( evt, batch ) => {
+			if ( command && !command.isEnabled ) {
+				return;
+			}
+
 			if ( batch.type == 'transparent' ) {
 				return;
 			}

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -272,6 +272,22 @@ describe( 'Autoformat', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph>foo <$text bold="true">bar</$text>[] baz</paragraph>' );
 		} );
+
+		it( 'should not format if the command is not enabled', () => {
+			model.schema.addAttributeCheck( ( context, attributeName ) => {
+				if ( attributeName == 'bold' ) {
+					return false;
+				}
+			} );
+
+			setData( model, '<paragraph>**foobar*[]</paragraph>' );
+
+			model.change( writer => {
+				writer.insertText( '*', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>**foobar**[]</paragraph>' );
+		} );
 	} );
 
 	describe( 'without commands', () => {

--- a/tests/inlineautoformatediting.js
+++ b/tests/inlineautoformatediting.js
@@ -3,6 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
+import Autoformat from '../src/autoformat';
 import InlineAutoformatEditing from '../src/inlineautoformatediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
@@ -18,7 +19,7 @@ describe( 'InlineAutoformatEditing', () => {
 	beforeEach( () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ Enter, Paragraph ]
+				plugins: [ Enter, Paragraph, Autoformat ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -64,7 +65,7 @@ describe( 'InlineAutoformatEditing', () => {
 		} );
 	} );
 
-	describe( 'Callback', () => {
+	describe( 'callback', () => {
 		it( 'should stop when there are no format ranges returned from testCallback', () => {
 			const formatSpy = testUtils.sinon.spy();
 			const testStub = testUtils.sinon.stub().returns( {
@@ -114,6 +115,27 @@ describe( 'InlineAutoformatEditing', () => {
 			} );
 
 			sinon.assert.notCalled( formatSpy );
+		} );
+
+		it( 'should not autoformat if callback returned false', () => {
+			setData( model, '<paragraph>Foobar[]</paragraph>' );
+
+			const p = model.document.getRoot().getChild( 0 );
+
+			const testCallback = () => ( {
+				format: [ model.createRange( model.createPositionAt( p, 0 ), model.createPositionAt( p, 3 ) ) ],
+				remove: [ model.createRange( model.createPositionAt( p, 0 ), model.createPositionAt( p, 3 ) ) ]
+			} );
+
+			const formatCallback = () => false;
+
+			new InlineAutoformatEditing( editor, testCallback, formatCallback ); // eslint-disable-line no-new
+
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>Foobar []</paragraph>' );
 		} );
 	} );
 

--- a/tests/undointegration.js
+++ b/tests/undointegration.js
@@ -20,7 +20,7 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
-describe( 'Autoformat', () => {
+describe( 'Autoformat undo integration', () => {
 	let editor, model, doc;
 
 	testUtils.createSinonSandbox();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `BlockAutoformatEditing` will not format if the command is disabled. `InlineAutoformatEditing` will not format if the callback returned `false`. Closes #64.