### PR TITLE
Numbered list works now with "1" instead of any digit

### DIFF
--- a/src/autoformat.js
+++ b/src/autoformat.js
@@ -56,7 +56,7 @@ export default class Autoformat extends Plugin {
 
 		if ( commands.get( 'numberedList' ) ) {
 			// eslint-disable-next-line no-new
-			new BlockAutoformatEditing( this.editor, /^\d+[.|)]\s$/, 'numberedList' );
+			new BlockAutoformatEditing( this.editor, /^1[.|)]\s$/, 'numberedList' );
 		}
 	}
 

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -117,6 +117,15 @@ describe( 'Autoformat', () => {
 
 			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">1. []</listItem>' );
 		} );
+
+		it( 'should not replace digit with numbered list item when digit is different than "1"', () => {
+			setData( model, '<paragraph>3.[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>3. []</paragraph>' );
+		} );
 	} );
 
 	describe( 'Heading', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Any digit followed by a dot won't trigger the numbered list. Now, only `1` is supported by the Autoformat plugin. Closes #60.
