### PR TITLE
Make basic styles autoformat implementations execute commands

### DIFF
--- a/src/autoformat.js
+++ b/src/autoformat.js
@@ -10,6 +10,7 @@
 import BlockAutoformatEditing from './blockautoformatediting';
 import InlineAutoformatEditing from './inlineautoformatediting';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import LiveRange from '@ckeditor/ckeditor5-engine/src/model/liverange';
 
 /**
  * Enables a set of predefined autoformatting actions.
@@ -167,11 +168,16 @@ function getCallbackFunctionForInlineAutoformat( editor, attributeKey ) {
 			return false;
 		}
 
-		const validRanges = editor.model.schema.getValidRanges( rangesToFormat, attributeKey );
+		const oldSelectionRange = LiveRange.fromRange( editor.model.document.selection.getFirstRange() );
 
-		for ( const range of validRanges ) {
-			writer.setAttribute( attributeKey, true, range );
+		for ( const range of rangesToFormat ) {
+			writer.setSelection( range );
+
+			command.execute( { forceValue: true } );
 		}
+
+		writer.setSelection( oldSelectionRange );
+		oldSelectionRange.detach();
 
 		// After applying attribute to the text, remove given attribute from the selection.
 		// This way user is able to type a text without attribute used by auto formatter.

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -252,33 +252,45 @@ describe( 'Autoformat', () => {
 
 	describe( 'Inline autoformat', () => {
 		it( 'should replace both "**" with bold', () => {
+			const command = editor.commands.get( 'bold' );
+			sinon.spy( command, 'execute' );
+
 			setData( model, '<paragraph>**foobar*[]</paragraph>' );
 			model.change( writer => {
 				writer.insertText( '*', doc.selection.getFirstPosition() );
 			} );
 
+			expect( command.execute.calledOnce ).to.be.true;
 			expect( getData( model ) ).to.equal( '<paragraph><$text bold="true">foobar</$text>[]</paragraph>' );
 		} );
 
 		it( 'should replace both "*" with italic', () => {
+			const command = editor.commands.get( 'italic' );
+			sinon.spy( command, 'execute' );
+
 			setData( model, '<paragraph>*foobar[]</paragraph>' );
 			model.change( writer => {
 				writer.insertText( '*', doc.selection.getFirstPosition() );
 			} );
 
+			expect( command.execute.calledOnce ).to.be.true;
 			expect( getData( model ) ).to.equal( '<paragraph><$text italic="true">foobar</$text>[]</paragraph>' );
 		} );
 
 		it( 'should replace both "`" with code', () => {
+			const command = editor.commands.get( 'code' );
+			sinon.spy( command, 'execute' );
+
 			setData( model, '<paragraph>`foobar[]</paragraph>' );
 			model.change( writer => {
 				writer.insertText( '`', doc.selection.getFirstPosition() );
 			} );
 
+			expect( command.execute.calledOnce ).to.be.true;
 			expect( getData( model ) ).to.equal( '<paragraph><$text code="true">foobar</$text>[]</paragraph>' );
 		} );
 
-		it( 'nothing should be replaces when typing "*"', () => {
+		it( 'nothing should be replaced when typing "*"', () => {
 			setData( model, '<paragraph>foobar[]</paragraph>' );
 			model.change( writer => {
 				writer.insertText( '*', doc.selection.getFirstPosition() );

--- a/tests/undointegration.js
+++ b/tests/undointegration.js
@@ -61,7 +61,7 @@ describe( 'Autoformat undo integration', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph><$text bold="true">foobar</$text>[]</paragraph>' );
 			editor.execute( 'undo' );
-			expect( getData( model ) ).to.equal( '<paragraph>**foobar**[]</paragraph>' );
+			expect( getData( model ) ).to.equal( '<paragraph>**[foobar]**</paragraph>' );
 		} );
 
 		it( 'should undo replacing "__" with bold', () => {
@@ -72,7 +72,7 @@ describe( 'Autoformat undo integration', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph><$text bold="true">foobar</$text>[]</paragraph>' );
 			editor.execute( 'undo' );
-			expect( getData( model ) ).to.equal( '<paragraph>__foobar__[]</paragraph>' );
+			expect( getData( model ) ).to.equal( '<paragraph>__[foobar]__</paragraph>' );
 		} );
 
 		it( 'should undo replacing "*" with italic', () => {
@@ -83,7 +83,7 @@ describe( 'Autoformat undo integration', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph><$text italic="true">foobar</$text>[]</paragraph>' );
 			editor.execute( 'undo' );
-			expect( getData( model ) ).to.equal( '<paragraph>*foobar*[]</paragraph>' );
+			expect( getData( model ) ).to.equal( '<paragraph>*[foobar]*</paragraph>' );
 		} );
 
 		it( 'should undo replacing "_" with italic', () => {
@@ -94,7 +94,7 @@ describe( 'Autoformat undo integration', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph><$text italic="true">foobar</$text>[]</paragraph>' );
 			editor.execute( 'undo' );
-			expect( getData( model ) ).to.equal( '<paragraph>_foobar_[]</paragraph>' );
+			expect( getData( model ) ).to.equal( '<paragraph>_[foobar]_</paragraph>' );
 		} );
 
 		it( 'should undo replacing "`" with code', () => {
@@ -105,7 +105,7 @@ describe( 'Autoformat undo integration', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph><$text code="true">foobar</$text>[]</paragraph>' );
 			editor.execute( 'undo' );
-			expect( getData( model ) ).to.equal( '<paragraph>`foobar`[]</paragraph>' );
+			expect( getData( model ) ).to.equal( '<paragraph>`[foobar]`</paragraph>' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Basic styles autoformat implementations will execute commands. Closes #70.

---

### Additional information

Unfortunately, the side effect of this change without any other changes is this issue: ckeditor/ckeditor5-undo#44.