### PR TITLE
BlockAutoformat should not react to text after inline element.

### DIFF
--- a/src/blockautoformatediting.js
+++ b/src/blockautoformatediting.js
@@ -94,7 +94,9 @@ export default class BlockAutoformatEditing {
 				return;
 			}
 
-			const match = pattern.exec( item.data );
+			const text = getStartText( editor.model.createRangeIn( item.parent ) );
+
+			const match = pattern.exec( text );
 
 			if ( !match ) {
 				return;
@@ -118,4 +120,24 @@ export default class BlockAutoformatEditing {
 			} );
 		} );
 	}
+}
+
+/**
+ * Returns the text from given renge up to the first inline element.
+ *
+ * @param {module:engine/model/range~Range} range
+ * @returns {String}
+ */
+export function getStartText( range ) {
+	let text = '';
+
+	for ( const item of range.getItems() ) {
+		if ( !( item.is( 'text' ) || item.is( 'textProxy' ) ) ) {
+			return text;
+		}
+
+		text = text + item.data;
+	}
+
+	return text;
 }

--- a/tests/autoformat.js
+++ b/tests/autoformat.js
@@ -81,6 +81,15 @@ describe( 'Autoformat', () => {
 
 			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">- []</listItem>' );
 		} );
+
+		it( 'should not replace asterisk character after <softBreak>', () => {
+			setData( model, '<paragraph>Foo<softBreak></softBreak>*[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>Foo<softBreak></softBreak>* []</paragraph>' );
+		} );
 	} );
 
 	describe( 'Numbered list', () => {
@@ -127,6 +136,15 @@ describe( 'Autoformat', () => {
 			} );
 
 			expect( getData( model ) ).to.equal( '<paragraph>3. []</paragraph>' );
+		} );
+
+		it( 'should not replace digit character after <softBreak>', () => {
+			setData( model, '<paragraph>Foo<softBreak></softBreak>1.[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>Foo<softBreak></softBreak>1. []</paragraph>' );
 		} );
 	} );
 
@@ -212,6 +230,15 @@ describe( 'Autoformat', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph># []</paragraph>' );
 		} );
+
+		it( 'should not replace hash character after <softBreak>', () => {
+			setData( model, '<paragraph>Foo<softBreak></softBreak>#[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>Foo<softBreak></softBreak># []</paragraph>' );
+		} );
 	} );
 
 	describe( 'Block quote', () => {
@@ -249,6 +276,15 @@ describe( 'Autoformat', () => {
 			} );
 
 			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">1. > []</listItem>' );
+		} );
+
+		it( 'should not replace greater-than character after <softBreak>', () => {
+			setData( model, '<paragraph>Foo<softBreak></softBreak>>[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<paragraph>Foo<softBreak></softBreak>> []</paragraph>' );
 		} );
 	} );
 

--- a/tests/blockautoformatediting.js
+++ b/tests/blockautoformatediting.js
@@ -156,6 +156,35 @@ describe( 'BlockAutoformatEditing', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
+		it( 'should not call callback when after inline element (typing after softBreak in a "matching" paragraph)', () => {
+			// Configure the schema.
+			model.schema.register( 'softBreak', {
+				allowWhere: '$text',
+				isInline: true
+			} );
+			editor.conversion.for( 'upcast' )
+				.elementToElement( {
+					model: 'softBreak',
+					view: 'br'
+				} );
+			editor.conversion.for( 'downcast' )
+				.elementToElement( {
+					model: 'softBreak',
+					view: ( modelElement, viewWriter ) => viewWriter.createEmptyElement( 'br' )
+				} );
+
+			const spy = testUtils.sinon.spy();
+			new BlockAutoformatEditing( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
+
+			setData( model, '<paragraph>* <softBreak></softBreak>[]</paragraph>' );
+
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( spy );
+		} );
+
 		it( 'should stop if callback returned false', () => {
 			new BlockAutoformatEditing( editor, /^[*]\s$/, () => false ); // eslint-disable-line no-new
 

--- a/tests/blockautoformatediting.js
+++ b/tests/blockautoformatediting.js
@@ -128,6 +128,34 @@ describe( 'BlockAutoformatEditing', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
+		it( 'should not call callback when after inline element', () => {
+			// Configure the schema.
+			model.schema.register( 'softBreak', {
+				allowWhere: '$text',
+				isInline: true
+			} );
+			editor.conversion.for( 'upcast' )
+				.elementToElement( {
+					model: 'softBreak',
+					view: 'br'
+				} );
+			editor.conversion.for( 'downcast' )
+				.elementToElement( {
+					model: 'softBreak',
+					view: ( modelElement, viewWriter ) => viewWriter.createEmptyElement( 'br' )
+				} );
+
+			const spy = testUtils.sinon.spy();
+			new BlockAutoformatEditing( editor, /^[*]\s/, spy ); // eslint-disable-line no-new
+
+			setData( model, '<paragraph>*<softBreak></softBreak>[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( spy );
+		} );
+
 		it( 'should stop if callback returned false', () => {
 			new BlockAutoformatEditing( editor, /^[*]\s$/, () => false ); // eslint-disable-line no-new
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: BlockAutoformat should not react to text after inline element. Closes ckeditor/ckeditor5#5671.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
